### PR TITLE
Non hardcoded makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 INST_PREFIX = /usr
 INST_LIBDIR = $(INST_PREFIX)/lib/lua/5.3
 
-MECAB_SO=/usr/lib/libmecab.so
+MECAB_LIBS = `mecab-config --libs`
 LIBFLAG=-shared
 
 all: lua-mecab.so
 
 lua-mecab.so: lua-mecab.o
-	$(CXX) $(LIBFLAG) lua-mecab.o $(MECAB_SO) -o lua-mecab.so
+	$(CXX) $(LIBFLAG) lua-mecab.o $(MECAB_LIBS) -o lua-mecab.so
 
 lua-mecab.o: lua-mecab.cpp
 	$(CXX) -I$(LUA_INCDIR) -fPIC -c lua-mecab.cpp -o lua-mecab.o

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lua-mecab.so: lua-mecab.o
 	$(CXX) $(LIBFLAG) lua-mecab.o $(MECAB_SO) -o lua-mecab.so
 
 lua-mecab.o: lua-mecab.cpp
-	$(CXX) -fPIC -c lua-mecab.cpp -o lua-mecab.o
+	$(CXX) -I$(LUA_INCDIR) -fPIC -c lua-mecab.cpp -o lua-mecab.o
 
 install:
 	cp lua-mecab.so $(INST_LIBDIR)/mecab.so


### PR DESCRIPTION
It is nice not to assume hardcoded path because libmecab.so is not always hold on /usr/lib/libmecab.so