### PR TITLE
Support lua 5.1 again

### DIFF
--- a/lua-mecab.cpp
+++ b/lua-mecab.cpp
@@ -77,7 +77,11 @@ extern "C" int luaopen_mecab(lua_State *L)
 {  
     // Register metatable for user data in registry
     luaL_newmetatable(L, "Mecab.Tagger");
-    luaL_setfuncs(L, gTaggerFuncs, 0);      
+#if LUA_VERSION_NUM >= 502
+    luaL_setfuncs(L, gTaggerFuncs, 0);
+#else
+    luaL_register(L, NULL, gTaggerFuncs);
+#endif
     lua_pushvalue(L, -1);
     lua_setfield(L, -2, "__index");  
 


### PR DESCRIPTION
ref. http://www.lua.org/manual/5.2/manual.html#8

Since Lua 5.2, luaL_register is deprecated. so it must use
luaL_register for Lua 5.1 and luaL_setfuncs for Lua 5.2 or later.