### PR TITLE
Use mecab-config to detect where mecab.h exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ INST_LIBDIR = $(INST_PREFIX)/lib/lua/5.3
 LUA_INCDIR = $(INST_PREFIX)/include
 
 MECAB_LIBS = `mecab-config --libs`
+MECAB_INCS = `mecab-config --inc-dir`
 LIBFLAG=-shared
 
 all: lua-mecab.so
@@ -15,7 +16,7 @@ lua-mecab.so: lua-mecab.o
 	$(CXX) $(LIBFLAG) lua-mecab.o $(MECAB_LIBS) -o lua-mecab.so
 
 lua-mecab.o: lua-mecab.cpp
-	$(CXX) -I$(LUA_INCDIR) -fPIC -c lua-mecab.cpp -o lua-mecab.o
+	$(CXX) -I$(LUA_INCDIR) -I$(MECAB_INCS) -fPIC -c lua-mecab.cpp -o lua-mecab.o
 
 install:
 	cp lua-mecab.so $(INST_LIBDIR)/mecab.so


### PR DESCRIPTION
In the previous version, it still assume that mecab.h is put under
standard place (/usr/include). if this header file is put under
customized place, luarock make fails to build it. This is more
portable way to detect mecab header correctly.